### PR TITLE
Improve link to answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The answers to those questions are based on my humble knowledge. If you find som
 
 ## NETWORKING
 
-[Answers here](/answers/networking.md#topic-networking)
+[Answers here](./answers/networking.md#topic-networking)
 
 1. Read the concept of TCP in [this wiki page](HTTPS://en.wikipedia.org/wiki/Transmission_Control_Protocol) and try to understand all the concepts of it (deeply):
     - How TCP open a connection? What does it need to open a connection?
@@ -88,7 +88,7 @@ The answers to those questions are based on my humble knowledge. If you find som
 
 ## OPERATING SYSTEM
 
-[Answers here](/answers/os.md#topic-operating-system)
+[Answers here](./answers/os.md#topic-operating-system)
 
 1. What is process, thread? What are the differences between them?
     - What data process, thread need to live? Why they said that Thread is a lightweight process?
@@ -156,7 +156,7 @@ The answers to those questions are based on my humble knowledge. If you find som
 
 ## DATABASE
 
-[Answers here](/answers/database.md#topic-database)
+[Answers here](./answers/database.md#topic-database)
 
 1. Compare Relational DB (SQL) vs NoSQL. It's also really nice to know about newSQL (a kind of auto sharding DB which support SQL stuff but scale like NoSQL)
     - How these 2 things can scale up?
@@ -203,7 +203,7 @@ The answers to those questions are based on my humble knowledge. If you find som
 
 ## SECURITY
 
-[Answers here](/answers/security.md#topic-security)
+[Answers here](./answers/security.md#topic-security)
 
 1. Hash vs Encrypt vs Encode
     - Are there any way we can crack Hash
@@ -224,7 +224,7 @@ The answers to those questions are based on my humble knowledge. If you find som
 
 ## PROGRAMMING PARADIGM
 
-[Answers here](/answers/programming-paradigm.md#topic-programming-paradigm)
+[Answers here](./answers/programming-paradigm.md#topic-programming-paradigm)
 
 1. OOP. What is OOP? Why should we use OOP?
     - What is the 4 principles of OOP?
@@ -247,7 +247,7 @@ The answers to those questions are based on my humble knowledge. If you find som
 
 ## SOFTWARE DEVELOPMENT PROCESS
 
-[Answers here](/answers/software-development-process.md#topic-software-development-process)
+[Answers here](./answers/software-development-process.md#topic-software-development-process)
 
 1. DDD. What is DDD?
     - 2 base foundations of DDD


### PR DESCRIPTION
Hi @tamhoang1412 , thank you for having this great resource, especially in making it open and accessible  (Markdown and GitHub).

If you don't mind, I hope it's ok to change the pseudo relative links to truly relative links.

In specific, the README file has several links to the answers folder. They started as `/` which implies it starts from the root path. For example, a `/answers/database.md` link from

```
https://github.com/tamhoang1412/backend-swe-interview-questions/blob/main/README.md
```

would result in:

```
https://github.com/tamhoang1412/backend-swe-interview-questions/blob/main/answers/database.md
```

This works fine in GitHub since GitHub has the implicit context that "root" here means:

```
https://github.com/tamhoang1412/backend-swe-interview-questions(/blob/main/)
```

However, it is difficult in other environment to actually know the correct "root". For example, in a generic web context, the "root" would means:

```
https://github.com/
```

Therefore, to have a better link in term of portability, I propose to change them to a true relative format, which basically means they should start with a `./`. Unlike the `/` link, this should work not only in GitHub but also in more generic environment and context, such as when you wanted to put this on a website.

I understand that this may not be your highest priority or concern. In that case, please feel free to dismiss my PR :D 